### PR TITLE
Fix discrepancy in doc names and repo yamls

### DIFF
--- a/applications/sinatra/manifests/deployment.yaml
+++ b/applications/sinatra/manifests/deployment.yaml
@@ -1,17 +1,17 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: noobernetes-sinatra
+  name: noobernetes
 spec:
   template:
     metadata:
-      name: noobernetes-sinatra
+      name: noobernetes
       labels:
-        service: noobernetes-sinatra
+        service: noobernetes-service
     spec:
       containers:
-      - name: noobernetes-sinatra-container
-        image: noobernetes-sinatra:latest
+      - name: noobernetes-container
+        image: noobernetes:hello-world
         resources:
           requests:
             cpu: 200m

--- a/applications/sinatra/manifests/service.yaml
+++ b/applications/sinatra/manifests/service.yaml
@@ -1,17 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: noobernetes
   labels:
-    service: noobernetes-sinatra
-  name: noobernetes-sinatra-service
+    service: noobernetes-service
 spec:
   type: NodePort
   ports:
-  - name: noobernetes-sinatra-port
+  - name: noobernetes-port
     port: 4000
     protocol: TCP
     targetPort: 4567
     nodePort: 30000
   selector:
-    service: noobernetes-sinatra
-    
+    service: noobernetes-service

--- a/tutorials/4-deploying-to-kubernetes.md
+++ b/tutorials/4-deploying-to-kubernetes.md
@@ -82,7 +82,7 @@ You should see some output like this:
 ```shell
 > kubectl expose deployment noobernetes --port=4000 --target-port=4567 --type=LoadBalancer --name=noobernetes
 Using docker VM
-service "noobernetes-sinatra" exposed
+service "noobernetes" exposed
 ```
 
 We've defined a Service, which can be thought of as a way to control access to a deployment or pod. As the actual running container changes (if it dies, or is restarted) the service is responsible for always allowing us to route traffic within our cluster to the correct pods.
@@ -92,7 +92,7 @@ Our service says that we want to expose our app on localhost:4000, pointing to t
 `kubectl get services noobernetes`
 
 ```shell
-> kubectl get services my-sinatra
+> kubectl get services noobernetes
 Using docker VM
 NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
 noobernetes   LoadBalancer   10.106.51.138   localhost     4000:31347/TCP   47m

--- a/tutorials/4-deploying-to-kubernetes.md
+++ b/tutorials/4-deploying-to-kubernetes.md
@@ -16,14 +16,14 @@ A manifest contains a description of the resource you wish to deploy. In this ca
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: noobernetes-deployment
+  name: noobernetes
 spec:
   replicas: 1
   template:
     metadata:
       name: noobernetes
       labels:
-        service: noobernetes
+        service: noobernetes-service
     spec:
       containers:
       - name: noobernetes-container
@@ -75,27 +75,27 @@ kubectl delete deployment <your_app_name>
 ### Exposing your app locally
 So we can now see that our pod is running. Like before with Docker, we need to make set it up so that we can access it on our host machine.
 
-`kubectl expose deployment noobernetes-deployment --port=4000 --target-port=4567 --type=LoadBalancer --name=noobernetes-service`
+`kubectl expose deployment noobernetes --port=4000 --target-port=4567 --type=LoadBalancer --name=noobernetes`
 
 You should see some output like this:
 
 ```shell
-> kubectl expose deployment noobernetes --port=4000 --target-port=4567 --type=LoadBalancer --name=noobernetes-service
+> kubectl expose deployment noobernetes --port=4000 --target-port=4567 --type=LoadBalancer --name=noobernetes
 Using docker VM
-service "noobernetes-service" exposed
+service "noobernetes-sinatra" exposed
 ```
 
 We've defined a Service, which can be thought of as a way to control access to a deployment or pod. As the actual running container changes (if it dies, or is restarted) the service is responsible for always allowing us to route traffic within our cluster to the correct pods.
 
 Our service says that we want to expose our app on localhost:4000, pointing to the 4567 port of the running container.
 
-`kubectl get services noobernetes-service`
+`kubectl get services noobernetes`
 
 ```shell
-> kubectl get services my-service
+> kubectl get services my-sinatra
 Using docker VM
 NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
-noobernetes-service   LoadBalancer   10.106.51.138   localhost     4000:31347/TCP   47m
+noobernetes   LoadBalancer   10.106.51.138   localhost     4000:31347/TCP   47m
 ```
 
 This tells us that its mapped localhost to the cluster-ip of our running container. Visit localhost:4000 and view your app!
@@ -107,19 +107,19 @@ Of course it would be a pain to have to remember to `expose` our deployment each
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    service: noobernetes
   name: noobernetes
+  labels:
+    service: noobernetes-service
 spec:
   type: NodePort
   ports:
-  - name: noobernetes
+  - name: noobernetes-port
     port: 4000
     protocol: TCP
     targetPort: 4567
     nodePort: 30000
   selector:
-    service: noobernetes
+    service: noobernetes-service
 ```
 
 This will allow us to access our application at `localhost:30000` after running the command `kubectl apply -f service.yaml` from within the `manifests` folder.


### PR DESCRIPTION
The tutorial was running commands on the deployment and service with different names, (i.e. `noobernetes-deployment` vs `noobernetes-sinatra`).

Simplified them and made them look the same.